### PR TITLE
WIP: make legacy array sections pass LLVM 11

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <llvm/IR/Value.h>
+#include <algorithm>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -7777,6 +7778,17 @@ public:
             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(m_arg))),
             module.get());
         llvm::Type* m_arg_llvm_type = llvm_utils->get_type_from_ttype_t_util(m_arg, ASRUtils::expr_type(m_arg), module.get());
+        auto ensure_pointer_type = [&](llvm::Value *value) -> llvm::Value* {
+#if LLVM_VERSION_MAJOR <= 16
+            if (!arr_type->isPointerTy()) return value;
+            llvm::Type *value_type = value->getType();
+            if (value_type != arr_type) {
+                value = builder->CreateBitCast(value, arr_type);
+            }
+#endif
+            return value;
+        };
+
         if( m_new == ASR::array_physical_typeType::PointerArray &&
             m_old == ASR::array_physical_typeType::DescriptorArray ) {
             if( ASR::is_a<ASR::StructInstanceMember_t>(*m_arg) ) {
@@ -7787,6 +7799,7 @@ public:
 #endif
             tmp = llvm_utils->CreateLoad2(data_type->getPointerTo(), arr_descr->get_pointer_to_data(m_arg, m_type, arg, module.get()));
             tmp = llvm_utils->create_ptr_gep2(data_type, tmp, arr_descr->get_offset(arr_type, arg));
+            tmp = ensure_pointer_type(tmp);
         } else if(
             m_new == ASR::array_physical_typeType::UnboundedPointerArray &&
             m_old == ASR::array_physical_typeType::DescriptorArray) {
@@ -7800,6 +7813,7 @@ public:
                     arr_descr->get_pointer_to_data(m_arg, m_type, arg, module.get()));
             tmp = llvm_utils->create_ptr_gep2(data_type, tmp,
                     arr_descr->get_offset(arr_type, arg));
+            tmp = ensure_pointer_type(tmp);
         } else if(
             m_new == ASR::array_physical_typeType::PointerArray &&
             m_old == ASR::array_physical_typeType::FixedSizeArray) {
@@ -7809,6 +7823,7 @@ public:
                 !ASR::is_a<ASR::ArrayConstructor_t>(*m_arg) ) {
                 tmp = llvm_utils->CreateGEP2(m_arg_llvm_type, tmp, 0);
             }
+            tmp = ensure_pointer_type(tmp);
         } else if(
             m_new == ASR::array_physical_typeType::UnboundedPointerArray &&
             m_old == ASR::array_physical_typeType::FixedSizeArray) {
@@ -7818,6 +7833,7 @@ public:
                 !ASR::is_a<ASR::ArrayConstructor_t>(*m_arg) ) {
                 tmp = llvm_utils->create_gep2(arr_type, tmp, 0);
             }
+            tmp = ensure_pointer_type(tmp);
         } else if (
             m_new == ASR::array_physical_typeType::SIMDArray &&
             m_old == ASR::array_physical_typeType::FixedSizeArray) {
@@ -12953,6 +12969,7 @@ public:
                     ASRUtils::symbol_get_past_external(x.m_name));
             }
             llvm::FunctionType* fntype = llvm_utils->get_function_type(*func, module.get());
+            reconcile_typed_pointer_args(fntype, args);
             tmp = builder->CreateCall(fntype, callee, args);
             return ;
         }
@@ -13132,6 +13149,7 @@ public:
                 }
             }
             args = convert_call_args(x, is_method);
+            reconcile_typed_pointer_args(fntype, args);
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (ASR::is_a<ASR::Variable_t>(*proc_sym) &&
                 llvm_symtab.find(h) != llvm_symtab.end()) {
@@ -13141,6 +13159,7 @@ public:
             fn = llvm_utils->CreateLoad2(fntype->getPointerTo(), fn);
             std::string m_name = ASRUtils::symbol_name(x.m_name);
             args = convert_call_args(x, is_method);
+            reconcile_typed_pointer_args(fntype, args);
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (llvm_symtab_fn.find(h) == llvm_symtab_fn.end()) {
             throw CodeGenError("Subroutine code not generated for '"
@@ -13170,6 +13189,7 @@ public:
             if (pass_arg) {
                 args.push_back(pass_arg);
             }
+            reconcile_typed_pointer_args(fn->getFunctionType(), args);
             builder->CreateCall(fn, args);
         }
     }
@@ -13240,9 +13260,47 @@ public:
         return pointer_to_struct;
     }
 
+    void reconcile_typed_pointer_args(llvm::FunctionType* fnty,
+            std::vector<llvm::Value*>& args) {
+#if LLVM_VERSION_MAJOR <= 16
+        size_t limit = std::min(args.size(), static_cast<size_t>(fnty->getNumParams()));
+        for (size_t i = 0; i < limit; i++) {
+            llvm::Type *param_type = fnty->getParamType(i);
+            if (!param_type->isPointerTy()) continue;
+            llvm::Value *&arg = args[i];
+            llvm::Type *arg_type = arg->getType();
+            if (!arg_type->isPointerTy()) {
+                arg = builder->CreateBitCast(arg, param_type);
+                continue;
+            }
+            if (arg_type == param_type) continue;
+            llvm::Type *arg_pointee = arg_type->getPointerElementType();
+            if (arg_pointee && arg_pointee->isStructTy()) {
+                llvm::StructType *struct_ty = llvm::cast<llvm::StructType>(arg_pointee);
+                if (struct_ty->getNumElements() > 0 && struct_ty->getElementType(0)->isPointerTy()) {
+                    llvm::Value *data_ptr_gep = builder->CreateStructGEP(arg_pointee, arg, 0);
+                    llvm::Value *data_ptr = builder->CreateLoad(struct_ty->getElementType(0), data_ptr_gep);
+                    if (data_ptr->getType() != param_type) {
+                        data_ptr = builder->CreateBitCast(data_ptr, param_type);
+                    }
+                    arg = data_ptr;
+                    continue;
+                }
+            }
+            if (arg_pointee && arg_pointee->isArrayTy()) {
+                arg = builder->CreateBitCast(arg, param_type);
+                continue;
+            } else {
+                arg = builder->CreateBitCast(arg, param_type);
+            }
+        }
+#endif
+    }
+
     llvm::Value* CreateCallUtil(llvm::FunctionType* fnty, llvm::Function* fn,
                                 std::vector<llvm::Value*>& args,
                                 ASR::ttype_t* asr_return_type) {
+        reconcile_typed_pointer_args(fnty, args);
         llvm::Value* return_value = builder->CreateCall(fn, args);
         return CreatePointerToStructTypeReturnValue(fnty, return_value,
                                                 asr_return_type);
@@ -13877,16 +13935,28 @@ public:
                         if (compiler_options.platform == Platform::Windows) {
                             tmp = llvm_utils->CreateAlloca(*builder, complex_type_8);
                             args.insert(args.begin(), tmp);
+#if LLVM_VERSION_MAJOR <= 16
+                            reconcile_typed_pointer_args(fn->getFunctionType(), args);
+#endif
                             builder->CreateCall(fn, args);
                             // Convert {double,double}* to {double,double}
                             tmp = llvm_utils->CreateLoad2(complex_type_8, tmp);
                         } else {
+#if LLVM_VERSION_MAJOR <= 16
+                            reconcile_typed_pointer_args(fn->getFunctionType(), args);
+#endif
                             tmp = builder->CreateCall(fn, args);
                         }
                     } else {
+#if LLVM_VERSION_MAJOR <= 16
+                        reconcile_typed_pointer_args(fn->getFunctionType(), args);
+#endif
                         tmp = builder->CreateCall(fn, args);
                     }
                 } else {
+#if LLVM_VERSION_MAJOR <= 16
+                    reconcile_typed_pointer_args(fn->getFunctionType(), args);
+#endif
                     tmp = builder->CreateCall(fn, args);
                 }
             } else {

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1623,6 +1623,7 @@ namespace LCompilers {
 
     llvm::Value* LLVMUtils::CreateGEP2(llvm::Type *t, llvm::Value *x,
             std::vector<llvm::Value *> &idx) {
+        x = builder->CreateBitCast(x, t->getPointerTo());
         return builder->CreateGEP(t, x, idx);
     }
 
@@ -1648,6 +1649,7 @@ namespace LCompilers {
             type = ptr_type_deprecated[x];
         }
         LCOMPILERS_ASSERT(type);
+        x = builder->CreateBitCast(x, type->getPointerTo());
         return builder->CreateInBoundsGEP(type, x, idx);
 #endif
     }


### PR DESCRIPTION
## Summary
- Reconcile legacy array-section lowering so LLVM 11 receives raw element pointers when calling BLAS/LAPACK entry points.
- Harden descriptor handling by normalising pointer casts before `CreateCall`, preventing mismatches when LLVM expects typed pointers (LLVM ≤16).
- Keep LLVM ≥17 behaviour intact by emitting harmless bitcasts whenever a descriptor pointer feeds the array descriptor helpers.

## Current Tip & Baseline
- Branch `feature/legacy-array-llvm11` now diverges from `feature/minpack-lmder1-mre` via:
  - Pointer type reconciliation in `src/libasr/codegen/asr_to_llvm.cpp`.
  - Safe GEP helpers in `src/libasr/codegen/llvm_utils.cpp`.
- Starting commit: `015a18441e09c7b3b0e3bb8921f6b8279a3bda5b` (squash of prior PR).

## Immediate Goals
1. Ensure every legacy array promotion inserts pointer casts that LLVM 11 accepts (no descriptor structs leak to implicit interfaces).
2. Normalise pointer arguments just before `CreateCall` for functions/subroutines so typed-pointer backends stay happy.
3. Guarantee helper GEP routines operate on the expected descriptor type by auto-bitcasting inputs.
4. Keep modern LLVM builds behaving identically (nothing beyond redundant bitcasts in typed-pointer mode).

## Completed Work
- Added `reconcile_typed_pointer_args()` to align call arguments with callee signatures (struct descriptor → data pointer, array → element pointer, scalar bitcasts) guarded for LLVM ≤16.
- Normalised descriptor→pointer conversions when lowering array physical casts, ensuring the result matches the target pointer type before returning.
- Updated array-descriptor GEP helpers to bitcast inputs to the appropriate descriptor pointer prior to indexing, avoiding LLVM 11 typed-pointer assertions.

## Validation Matrix
| Toolchain | Status | Notes |
| --- | --- | --- |
| LLVM 20 (`lf-llvm20`) | ✅ done | `cmake --build build -j` (Debug w/ LLVM 20 toolchain) + `./run_tests.py -b llvm -t lapack_03`. |
| LLVM 21 (`lf-llvm21`) | 🔄 pending | No regressions expected; re-run once LLVM 11 fixes settle. |
| LLVM 11 (`lf-llvm11`) | ✅ done | `FC=$PWD/build-llvm11/src/bin/lfortran bash ci/test_third_party_codes.sh` (full third-party suite, includes Reference-LAPACK, POT3D, Minpack, etc.). |

## Reproduction Checklist (LLVM 11)
1. Create env & build:
   ```bash
   source <(micromamba shell hook -s bash)
   micromamba activate lf-llvm11
   cmake -S . -B build-llvm11 -G Ninja \
         -DCMAKE_BUILD_TYPE=Debug \
         -DWITH_LLVM=ON -DWITH_RUNTIME_STACKTRACE=yes \
         -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
         -DCMAKE_C_COMPILER=$CONDA_PREFIX/bin/clang \
         -DCMAKE_CXX_COMPILER=$CONDA_PREFIX/bin/clang++ \
         -DZLIB_LIBRARY=$CONDA_PREFIX/lib/libz.so \
         -DZLIB_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DLIBUNWIND_LIBRARY=$CONDA_PREFIX/lib/libunwind.so \
         -DLIBUNWIND_INCLUDE_DIR=$CONDA_PREFIX/include \
         -DCMAKE_EXE_LINKER_FLAGS=-L$CONDA_PREFIX/lib \
         -DCMAKE_SHARED_LINKER_FLAGS=-L$CONDA_PREFIX/lib
   cmake --build build-llvm11 -j
   ```
2. Validate third-party suite:
   ```bash
   FC=$PWD/build-llvm11/src/bin/lfortran bash ci/test_third_party_codes.sh
   ```

## Notes
- `ci/test_third_party_codes.sh` is long-running (~25 minutes on this host); expect multiple builds (POT3D, modern/legacy Minpack, Reference-LAPACK).
- Reference-LAPACK build now succeeds without manual intervention under LLVM 11—no descriptor mismatches or GEP assertions remain.
- Any additional regressions should be caught by the existing lapack/minpack integration tests (`./run_tests.py -b llvm -t lapack_03`, etc.).

## Exit Criteria
- Third-party sweep (command above) passes on LLVM 11. ✅
- Spot-check integration tests (`./run_tests.py -b llvm -t lapack_03`) continue to pass on LLVM 20/21. ✅ for LLVM 20; rerun on LLVM 21 before promoting PR.
- Once LLVM 21 check passes, convert this draft to ready-for-review and merge back into `feature/minpack-lmder1-mre`.
